### PR TITLE
Bilibili failing (2019-05-24)

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -31,6 +31,8 @@ class YouGetTests(unittest.TestCase):
             'http://www.youtube.com/attribution_link?u=/watch?v%3DldAKIzq7bvs%26feature%3Dshare',  # noqa
             info_only=True
         )
+    def test_bilibili(self):
+        bilibili.download('https://www.bilibili.com/video/av3777239', info_only=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
```
D:\>you-get https://www.bilibili.com/video/av3777239 --debug
[DEBUG] get_content: https://www.bilibili.com/video/av3777239
[DEBUG] get_content: https://www.bilibili.com/video/av3777239
you-get: version 0.4.1302, a tiny downloader that scrapes the web.
you-get: Namespace(URL=['https://www.bilibili.com/video/av3777239'], auto_rename
=False, cookies=None, debug=True, extractor_proxy=None, force=False, format=None
, help=False, http_proxy=None, info=False, input_file=None, insecure=False, itag
=None, json=False, no_caption=False, no_merge=False, no_proxy=False, output_dir=
'.', output_filename=None, password=None, player=None, playlist=False, socks_pro
xy=None, stream=None, timeout=600, url=False, version=False)
Traceback (most recent call last):
  File "c:\python37\lib\runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "c:\python37\lib\runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "C:\Python37\Scripts\you-get.exe\__main__.py", line 9, in <module>
  File "c:\python37\lib\site-packages\you_get\__main__.py", line 92, in main
    main(**kwargs)
  File "c:\python37\lib\site-packages\you_get\common.py", line 1733, in main
    script_main(any_download, any_download_playlist, **kwargs)
  File "c:\python37\lib\site-packages\you_get\common.py", line 1621, in script_m
ain
    **extra
  File "c:\python37\lib\site-packages\you_get\common.py", line 1284, in download
_main
    download(url, **kwargs)
  File "c:\python37\lib\site-packages\you_get\common.py", line 1724, in any_down
load
    m.download(url, **kwargs)
  File "c:\python37\lib\site-packages\you_get\extractor.py", line 48, in downloa
d_by_url
    self.prepare(**kwargs)
  File "c:\python37\lib\site-packages\you_get\extractors\bilibili.py", line 179,
 in prepare
    pn = initial_state['videoData']['videos']
KeyError: 'videos'
```